### PR TITLE
Add some additional types from WP block editor packages

### DIFF
--- a/wordpress__block-editor/index.d.ts
+++ b/wordpress__block-editor/index.d.ts
@@ -8,8 +8,9 @@
  */
 declare module '@wordpress/block-editor' {
 	import {ComponentClass, ComponentType, FunctionComponent, MouseEvent, MutableRefObject, ReactElement, ReactNode, RefCallback} from 'react';
-	import {ColorOption, ColorPalette as PaletteComponent, Control, GradientOption, PanelBody, PopoverProps, WPBlockTypeIconRender} from '@wordpress/components';
+	import {ColorOption, ColorPalette as PaletteComponent, Control, Fill, GradientOption, PanelBody, PopoverProps, WPBlockTypeIconRender} from '@wordpress/components';
 	import {BlockIcon as Icon, ChildBlocks, CreateBlock} from '@wordpress/blocks';
+    import {StoreDescriptor} from '@wordpress/data';
 	import {ALL_TYPES} from '@lipemat/js-boilerplate/mime';
 	import {SelectedMedia} from '@lipemat/js-boilerplate/global/wp-media';
 
@@ -172,8 +173,7 @@ declare module '@wordpress/block-editor' {
 	 *
 	 * @link https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inspector-controls/README.md
 	 */
-	interface InspectorControls extends FunctionComponent {
-	}
+	interface InspectorControls extends Fill {};
 
 	export type AlignOptions = 'left' | 'center' | 'right' | 'space-between';
 
@@ -337,7 +337,8 @@ declare module '@wordpress/block-editor' {
 	export const ColorPalette: ComponentType<ColorPalette>;
 	export const ColorPaletteControl: ComponentType<ColorPaletteControl>;
 	export const CopyHandler: ComponentType<CopyHandler>;
-	export const InspectorControls: InspectorControls;
+    export const InspectorControls: ComponentType<InspectorControls>;
+    export const InspectorControlsAdvanced: ComponentType<InspectorControls>;
 	export const JustifyToolbar: ComponentType<JustifyToolbar>;
 	export const MediaPlaceholder: ComponentType<MediaPlaceholder>;
 	export const MediaUpload: ComponentClass<MediaUpload>;
@@ -347,6 +348,7 @@ declare module '@wordpress/block-editor' {
 	export const useBlockDisplayInformation: useBlockDisplayInformation;
 	export const useBlockProps: useBlockProps;
 	export const useInnerBlocksProps: useInnerBlocksProps;
+    export const store: StoreDescriptor;
 
 
 	export default interface BlockEditor {
@@ -361,7 +363,8 @@ declare module '@wordpress/block-editor' {
 		getColorObjectByColorValue: typeof getColorObjectByColorValue;
 		getGradientSlugByValue: typeof getGradientSlugByValue;
 		getGradientValueBySlug: typeof getGradientValueBySlug;
-		InspectorControls: InspectorControls;
+		InspectorControls: ComponentType<InspectorControls>;
+		InspectorControlsAdvanced: ComponentType<InspectorControls>;
 		JustifyToolbar: ComponentType<JustifyToolbar>;
 		MediaPlaceholder: ComponentType<MediaPlaceholder>;
 		MediaUpload: ComponentType<MediaUpload>;
@@ -372,5 +375,6 @@ declare module '@wordpress/block-editor' {
 		useBlockProps: useBlockProps;
 		useInnerBlocksProps: useInnerBlocksProps;
 		useSetting: typeof useSetting;
+        store: typeof store;
 	}
 }

--- a/wordpress__block-editor/index.d.ts
+++ b/wordpress__block-editor/index.d.ts
@@ -10,7 +10,7 @@ declare module '@wordpress/block-editor' {
 	import {ComponentClass, ComponentType, FunctionComponent, MouseEvent, MutableRefObject, ReactElement, ReactNode, RefCallback} from 'react';
 	import {ColorOption, ColorPalette as PaletteComponent, Control, Fill, GradientOption, PanelBody, PopoverProps, WPBlockTypeIconRender} from '@wordpress/components';
 	import {BlockIcon as Icon, ChildBlocks, CreateBlock} from '@wordpress/blocks';
-    import {StoreDescriptor} from '@wordpress/data';
+	import {StoreDescriptor} from '@wordpress/data';
 	import {ALL_TYPES} from '@lipemat/js-boilerplate/mime';
 	import {SelectedMedia} from '@lipemat/js-boilerplate/global/wp-media';
 
@@ -330,6 +330,7 @@ declare module '@wordpress/block-editor' {
 		Content: ComponentType<{}>;
 	}
 
+	export function getBlockCount( state: Object, rootClientId: string | null ) : number;
 
 	export const BlockControls: ComponentType<BlockControls>;
 	export const BlockIcon: ComponentType<BlockIcon>;
@@ -348,8 +349,7 @@ declare module '@wordpress/block-editor' {
 	export const useBlockDisplayInformation: useBlockDisplayInformation;
 	export const useBlockProps: useBlockProps;
 	export const useInnerBlocksProps: useInnerBlocksProps;
-    export const store: StoreDescriptor;
-
+	export const store: string = 'core/block-editor';
 
 	export default interface BlockEditor {
 		BlockControls: ComponentType<BlockControls>;
@@ -358,6 +358,7 @@ declare module '@wordpress/block-editor' {
 		ColorPalette: ComponentType<ColorPalette>;
 		ColorPaletteControl: ComponentType<ColorPaletteControl>;
 		CopyHandler: ComponentType<CopyHandler>;
+		getBlockCount: typeof getBlockCount;
 		getColorClassName: typeof getColorClassName;
 		getColorObjectByAttributeValues: typeof getColorObjectByAttributeValues;
 		getColorObjectByColorValue: typeof getColorObjectByColorValue;
@@ -375,6 +376,7 @@ declare module '@wordpress/block-editor' {
 		useBlockProps: useBlockProps;
 		useInnerBlocksProps: useInnerBlocksProps;
 		useSetting: typeof useSetting;
-        store: typeof store;
+		store: typeof store;
 	}
+
 }

--- a/wordpress__blocks/index.d.ts
+++ b/wordpress__blocks/index.d.ts
@@ -6,7 +6,7 @@
  * @link https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/wordpress__blocks/index.d.ts
  */
 declare module '@wordpress/blocks' {
-	import {BlockClientId, CoreBlocks, CoreBlocksDispatch} from '@wordpress/data';
+	import {BlockClientId, CoreBlocks, CoreBlocksDispatch, StoreDescriptor} from '@wordpress/data';
 	import {ReactElement, SVGProps} from 'react';
 	import {iconType} from '@wordpress/components';
 
@@ -557,6 +557,8 @@ declare module '@wordpress/blocks' {
 	 */
 	export function unregisterBlockVariation( blockName: string, variationName: string ): void;
 
+	export const store: string = 'core/blocks';
+
 	export default interface Blocks {
 		createBlock: typeof createBlock;
 		createBlocksFromInnerBlocksTemplate: typeof createBlocksFromInnerBlocksTemplate;
@@ -579,6 +581,7 @@ declare module '@wordpress/blocks' {
 		serialize: typeof serialize;
 		setDefaultBlockName: typeof setDefaultBlockName;
 		setGroupingBlockName: typeof setGroupingBlockName;
+		store: typeof store;
 		unregisterBlockStyle: typeof unregisterBlockStyle;
 		unregisterBlockType: typeof unregisterBlockType;
 		unregisterBlockVariation: typeof unregisterBlockVariation;

--- a/wordpress__blocks/index.d.ts
+++ b/wordpress__blocks/index.d.ts
@@ -527,6 +527,12 @@ declare module '@wordpress/blocks' {
 	export function registerBlockVariation<Attr>( blockName: string, variation: BlockVariation<Attr> ): void;
 
 	/**
+	 * Returns block variations by block name.
+	 *
+	 */
+	export function getBlockVariations<Attr>( blockName: string, scope?: Array<WPBlockVariationScope> ): Array<BlockVariation> | null;
+
+	/**
 	 * @link https://developer.wordpress.org/block-editor/reference-guides/packages/packages-blocks/#setdefaultblockname
 	 * @link https://github.dev/WordPress/gutenberg/tree/trunk/packages/blocks/src/api
 	 */
@@ -557,6 +563,7 @@ declare module '@wordpress/blocks' {
 		getBlockSupport: typeof getBlockSupport;
 		getBlockType: typeof getBlockType;
 		getBlockTypes: typeof getBlockTypes;
+		getBlockVariations: typeof getBlockVariations;
 		getCategories: typeof getCategories;
 		getChildBlockNames: typeof getChildBlockNames;
 		getDefaultBlockName: typeof getDefaultBlockName;

--- a/wordpress__data/index.d.ts
+++ b/wordpress__data/index.d.ts
@@ -463,6 +463,7 @@ not yet been saved.
 		canInsertBlocks: () => any;
 		didAutomaticChange: () => any;
 		getAdjacentBlockClientId: () => any;
+		getBlockCount: () => any;
 		getBlockHierarchyRootClientId: () => any;
 		getBlockInsertionPoint: () => any;
 		getBlockListSettings: () => any;
@@ -516,7 +517,72 @@ not yet been saved.
 		isValidTemplate: () => any;
 	}
 
+	type CoreBlockEditorDispatch = {
+		// todo: properly type these methods.
+		failResolution: () => any;
+		failResolutions: () => any;
+		finishResolution: () => any;
+		finishResolutions: () => any;
+		invalidateResolution: () => any;
+		invalidateResolutionForStore: () => any;
+		invalidateResolutionForStoreSelector: () => any;
+		startResolution: () => any;
+		startResolutions: () => any;
+		clearSelectedBlock: () => any;
+		duplicateBlocks: () => any;
+		enterFormattedText: () => any;
+		exitFormattedText: () => any;
+		flashBlock: () => any;
+		hideInsertionPoint: () => any;
+		insertAfterBlock: () => any;
+		insertBeforeBlock: () => any;
+		insertBlock: () => any;
+		insertBlocks: () => any;
+		insertDefaultBlock: () => any;
+		mergeBlocks: () => any;
+		moveBlockToPosition: () => any;
+		moveBlocksDown: () => any;
+		moveBlocksToPosition: () => any;
+		moveBlocksUp: () => any;
+		multiSelect: () => any;
+		receiveBlocks: () => any;
+		removeBlock: () => any;
+		removeBlocks: () => any;
+		replaceBlock: () => any;
+		replaceBlocks: () => any;
+		replaceInnerBlocks: () => any;
+		resetBlocks: () => any;
+		resetSelection: () => any;
+		selectBlock: () => any;
+		selectNextBlock: () => any;
+		selectPreviousBlock: () => any;
+		selectionChange: () => any;
+		setBlockMovingClientId: () => any;
+		setBlockVisibility: () => any;
+		setHasControlledInnerBlocks: () => any;
+		setNavigationMode: () => any;
+		setTemplateValidity: () => any;
+		showInsertionPoint: () => any;
+		startDraggingBlocks: () => any;
+		startMultiSelect: () => any;
+		startTyping: () => any;
+		stopDraggingBlocks: () => any;
+		stopMultiSelect: () => any;
+		stopTyping: () => any;
+		synchronizeTemplate: () => any;
+		toggleBlockHighlight: () => any;
+		toggleBlockMode: () => any;
+		toggleSelection: () => any;
+		updateBlock: () => any;
+		updateBlockAttributes: () => any;
+		updateBlockListSettings: () => any;
+		updateSettings: () => any;
+		validateBlocksToTemplate: () => any;
+	}
+
 	export function select( store: 'core/block-editor' ): CoreBlockEditor & SelectShared<CoreBlockEditor>;
+
+	export function dispatch( store: 'core/block-editor' ): CoreBlockEditorDispatch;
 
 	/**
 	 * @link https://developer.wordpress.org/block-editor/reference-guides/data/data-core-edit-post/
@@ -1087,8 +1153,8 @@ not yet been saved.
 
 	export function dispatch<Methods extends ActionFunctions>( store: string ): Methods;
 
-	type withDispatch = <T>( callback: ( dispatchFunction: typeof dispatch, ownProps: T, {select: select} ) => T, component: ComponentType<T> ) => ComponentType<T>;
-	type withSelect = <T>( callback: ( callback: ( selectFunction: typeof select ) => T, ownProps: T ) => T, component: ComponentType<T> ) => ComponentType<T>;
+	type withDispatch = <T>( callback: ( dispatchFunction: typeof dispatch, ownProps: T, {select: select} ) => T, component?: ComponentType<T> ) => ComponentType<T>;
+	type withSelect = <T>( callback: ( callback: ( selectFunction: typeof select ) => T, ownProps: T ) => T, component?: ComponentType<T> ) => ComponentType<T>;
 
 	export const AsyncModeProvider: ComponentType<{
 		value: boolean
@@ -1102,7 +1168,7 @@ not yet been saved.
 	 * @link https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#useselect
 	 */
 	export const useSelect: typeof select;
-	export const withDispatch: withDispatch;
+	export const withDispatch: withDispatch; //<DispatchFunction>: ( WrappedComponent : Component ) => withDispatch( DispatchFunction, WrappedComponent );
 	export const withSelect: withSelect;
 
 	/**


### PR DESCRIPTION
Work in progress that I'll be adding to as I discover them, but I wanted to open this PR as a draft in case they're necessary anywhere else.

* Add `wp.blocks.getBlockVariations` type