### PR TITLE
Add missing properties in EntityRecordResolution in @wordpress/core-data

### DIFF
--- a/wordpress__core-data/index.d.ts
+++ b/wordpress__core-data/index.d.ts
@@ -45,6 +45,14 @@ declare module '@wordpress/core-data' {
 		hasResolved: boolean;
 		/** Resolution status */
 		status: Status;
+		/**
+		 * The total number of available items (if not paginated).
+		 */
+		totalItems: number | null;
+		/**
+		 * The total number of pages.
+		 */
+		totalPages: number | null;
 	}
 
 	interface EntityRecordsResolution<RecordType> extends Omit<EntityRecordResolution<RecordType>, 'record'> {


### PR DESCRIPTION
The properties added use the same types found in the core-data package of the Gutenberg repository: https://github.com/WordPress/gutenberg/blob/e9a8c6ae15160d4c522ee7520b5ed6cf8343528f/packages/core-data/src/hooks/use-entity-records.ts#L18