### PR TITLE
Add type for settings parameter on registerFormatType function

### DIFF
--- a/wordpress__rich-text/index.d.ts
+++ b/wordpress__rich-text/index.d.ts
@@ -58,7 +58,7 @@ declare module '@wordpress/rich-text' {
 	 * @link https://developer.wordpress.org/block-editor/how-to-guides/format-api/
 	 * @link https://developer.wordpress.org/block-editor/reference-guides/packages/packages-rich-text/#registerformattype
 	 */
-	export function registerFormatType( name: string, settings ): WPFormat | undefined;
+	export function registerFormatType( name: string, settings: WPFormat ): WPFormat | undefined;
 
 	/**
 	 * Toggles a format object to a Rich Text value at the current selection.


### PR DESCRIPTION
Using same type found on core-data package of the Gutenberg repository https://github.com/WordPress/gutenberg/blob/f32a49ec303eb74ec2955c50bfc9262a0bffac84/packages/rich-text/src/register-format-type.js#L28